### PR TITLE
riscv-iommu: resolve translate iova error

### DIFF
--- a/drivers/iommu/riscv/io_pgtable.c
+++ b/drivers/iommu/riscv/io_pgtable.c
@@ -218,7 +218,7 @@ static phys_addr_t riscv_iommu_iova_to_phys(struct io_pgtable_ops *ops,
 	if (!pte || !pte_present(*pte))
 		return 0;
 
-	return (pfn_to_phys(pte_pfn(*pte)) | (iova & PAGE_MASK));
+	return (pfn_to_phys(pte_pfn(*pte)) | (iova & ~PAGE_MASK));
 }
 
 static void riscv_iommu_tlb_inv_all(void *cookie)


### PR DESCRIPTION
    PAGE_MASK is 0xff...fff000
    here should use 0xfff or ~PAGE_MASK to calculate page internal offset